### PR TITLE
Add error message if username or email not unique

### DIFF
--- a/src/components/user/UserCreate.vue
+++ b/src/components/user/UserCreate.vue
@@ -30,6 +30,8 @@
     <button class="submit" :disabled="!submitEnabled" @click="createUser">
       Sign up
     </button>
+    <span class="register-message"><br>{{registerMessage}}<br></span>
+
   </div>
 </template>
 
@@ -48,6 +50,7 @@
           email: "",
           password: "",
         },
+        registerMessage: "",
       }
     },
     computed: {
@@ -68,6 +71,8 @@
           })
           .catch(err => {
             console.error(`Signup failed: ${err.response.data.error}`)
+            this.setRegisterMessage("Your username has already been taken, or there's an existing account with this email. Please enter a unique username/email.")
+
           })
           .then(() => this.resetForm())
       },
@@ -78,6 +83,12 @@
           last: "",
           email: "",
           password: "",
+        }
+      },
+      setRegisterMessage: function(msg, disappear=true) {
+        this.registerMessage = msg;
+        if (disappear) {
+          setTimeout(() => this.registerMessage = "", 10000);
         }
       },
     },


### PR DESCRIPTION
Add error message "Your username has already been taken, or there's an existing account with this email. Please enter a unique username/email."

Note: not sure how to tell which field (username or email) is unique from the Sequilize unique constraint, but perhaps the error message is useful enough?

Referring to change from #42 

![image](https://user-images.githubusercontent.com/8744689/103240050-15d66100-4904-11eb-9201-05c177afa2cd.png)
