### PR TITLE
Add loading screen when user requests pw reset link

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -99,7 +99,7 @@ router.post('/forgotpassword', (req, res) => {
         subject: 'NB V2 - Forgot Your Password',
         text: 'Hello ' + user.username + '!\n\nYou indicated that you have forgotten your password for NB V2.' + 
         '\n\nPlease click on this link to reset your password: \n' + link + 
-        '\n\nIf you believe that this is a mistake, please contact us at nb@mit.edu or change your password on your user settings page.'
+        '\n\nIf you believe that this is a mistake, please contact us or change your password on your user settings page.'
       };
 
       transporter.sendMail(mailOptions, function(error, info){

--- a/src/components/user/UserLogin.vue
+++ b/src/components/user/UserLogin.vue
@@ -31,7 +31,16 @@
 
 <script>
   import axios from "axios"
+  import Vue from 'vue'
+  import loading from 'vuejs-loading-screen'
   import { eventBus } from "../../main"
+
+  Vue.use(loading, {
+    bg: '#4a2270ad',
+    icon: 'refresh',
+    size: 3,
+    icon_color: 'white',
+  })
 
   export default {
     name: "user-login",
@@ -77,11 +86,14 @@
         this.message = null
       },
       forgotPassword: function() {
+        this.$isLoading(true) // show loading screen      
         axios.post("/api/users/forgotpassword", this.user)
           .then(() => {
+            this.$isLoading(false) // hide loading screen      
             this.setForgotPasswordMessage("Email sent")
           })
-          .catch(err => {
+          .catch(err => {            
+            this.$isLoading(false) // hide loading screen      
             this.setForgotPasswordMessage("No user with that email. Please try again.")
           })
       },


### PR DESCRIPTION
Add loading screen (same one as upload csv) to pw reset since it can take a while to send reset emails

![image](https://user-images.githubusercontent.com/8744689/104074536-400e0580-51c5-11eb-92f3-e82f850f230b.png)
