### PR TITLE
Helen/optimize get annotations query final

### DIFF
--- a/models/Annotations/Threads.js
+++ b/models/Annotations/Threads.js
@@ -23,6 +23,7 @@ const thread = (sequelize, DataTypes) => {
         Thread.belongsTo(models.Annotation, {as: 'HeadAnnotation', foreignKey:{allowNull: false}, constraints: false});
         Thread.belongsToMany(models.User, {as: 'SeenUsers', through: 'user_seen'});
         Thread.belongsToMany(models.User, {as: 'RepliedUsers', through: 'user_replied'});
+        Thread.hasMany(models.Annotation, {as: 'AllAnnotations', foreignKey:{name: 'thread_id', allowNull: false}});
       }
     }
   });

--- a/models/Annotations/Threads.js
+++ b/models/Annotations/Threads.js
@@ -23,7 +23,7 @@ const thread = (sequelize, DataTypes) => {
         Thread.belongsTo(models.Annotation, {as: 'HeadAnnotation', foreignKey:{allowNull: false}, constraints: false});
         Thread.belongsToMany(models.User, {as: 'SeenUsers', through: 'user_seen'});
         Thread.belongsToMany(models.User, {as: 'RepliedUsers', through: 'user_replied'});
-        Thread.hasMany(models.Annotation, {as: 'AllAnnotations', foreignKey:{name: 'thread_id', allowNull: false}});
+        Thread.hasMany(models.Annotation, {as: 'AllAnnotations', foreignKey:{name: 'thread_id'}});
       }
     }
   });

--- a/models/utils.js
+++ b/models/utils.js
@@ -148,6 +148,40 @@ module.exports = function(models){
         )
       );
     },
+    createAnnotation: function(location, head, instructors, sessionUserId) {
+      let annotation = {}
+      let range = location.HtmlLocation;
+
+      annotation.id = head.id;
+      annotation.range = {
+        start: range.start_node,
+        end: range.end_node,
+        startOffset: range.start_offset,
+        endOffset: range.end_offset
+      };
+      annotation.parent = null;
+      annotation.timestamp = head.dataValues.created_at;
+      annotation.author = head.Author.id;
+      annotation.authorName = head.Author.first_name + " " + head.Author.last_name;
+      annotation.instructor = instructors.has(head.Author.id);
+      annotation.html = head.content;
+      annotation.hashtags = head.Tags.map(tag => tag.tag_type_id);
+      annotation.people = head.TaggedUsers.map(userTag => userTag.id);
+      annotation.visibility = head.visibility;
+      annotation.anonymity = head.anonymity;
+      annotation.replyRequestedByMe = head.ReplyRequesters
+        .reduce((bool, user)=> bool || user.id == sessionUserId, false);
+      annotation.replyRequestCount = head.ReplyRequesters.length;
+      annotation.starredByMe = head.Starrers
+        .reduce((bool, user)=> bool || user.id == sessionUserId, false);
+      annotation.starCount = head.Starrers.length;
+      annotation.seenByMe = location.Thread.SeenUsers
+        .reduce((bool, user)=> bool || user.id == sessionUserId, false);
+      annotation.bookmarked = head.Bookmarkers
+        .reduce((bool, user)=> bool || user.id == sessionUserId, false);
+      
+      return annotation
+    },
     createFile: function(parentId, filename, filepath){
       return FileSystemObject.findByPk(parentId, {include:[{association: 'Class'}]})
       .then((folder) => {


### PR DESCRIPTION
Add and optimize GET /annotations/new_annotation query to get all head threads + all subsequent child replies. Return all of them to the client, so that we don't need to continuously query for every single reply.

Note: this is a NEW endpoint (the old GET /annotations/annotation still exists since the nbclient relies on it.) We can update the old enpoint to this new one when we make the appropriate changes to the nbclient code base. https://github.com/haystack/nbclient/pull/8

Also: 
- Used sets instead of lists to optimize
- Add separate:true for join associations (https://github.com/sequelize/sequelize/issues/4868, https://stackoverflow.com/questions/37964763/what-does-separate-in-sequelize-mean)