### PR TITLE
be more specific about user account creation error messages

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -70,7 +70,7 @@ router.post('/register', (req, res) => {
       res.status(200).json({msg: "registered"});
     }).catch((err)=>{
       console.log("error:" + err);
-      res.status(400).json({msg: "Error registering"})
+      res.status(400).json({msg: err.errors[0].message})
     })
 });
 
@@ -96,7 +96,8 @@ router.post('/forgotpassword', (req, res) => {
 
       transporter.sendMail(mailOptions, function(error, info){
         if (error) {
-          console.log(error);
+          console.log("Error sending mail: " + error);
+          res.status(400).json({msg: "Error sending mail"})
         } else {
           console.log('Email sent: ' + info.response);
           res.status(200).json({email: req.body.email});

--- a/src/components/user/UserCreate.vue
+++ b/src/components/user/UserCreate.vue
@@ -72,8 +72,17 @@
                 eventBus.$emit('signin-success')
                 this.resetForm()
             } catch (error) {
-                console.error(`Signup failed: ${error.response.data.msg}`)
-                this.setRegisterMessage("There is already any account configured for this username/email. If you don't know the password, please use the password reset option.")
+                let msg = error.response.data.msg
+                console.error(`Signup failed: ${msg}`)
+                if (msg.includes("unique")) {
+                  if (msg.includes("username")) {
+                    this.setRegisterMessage("There is already any account configured for this username. Please use a different one, or you can use the Reset Password option to access the account.")
+                  } else if (msg.includes("email")) {
+                    this.setRegisterMessage("There is already any account configured for this email. Please use a different one, or you can use the Reset Password option to access the account.")
+                  }
+                } else if (msg.includes("isEmail")) {
+                  this.setRegisterMessage("Please enter a valid email with the correct format, such as test@mail.com")
+                } 
             }
         },
         resetForm: function() {

--- a/src/components/user/UserLogin.vue
+++ b/src/components/user/UserLogin.vue
@@ -18,7 +18,7 @@
       Sign in
     </button>
     <br><br>
-    <h3 class="title">Forgot Your Password</h3>
+    <h3 class="title">Reset Your Password</h3>
     <div class="group">
       <label for="login-email"> Email: </label>
       <input id="login-email" type="text" v-model="user.email">


### PR DESCRIPTION
1.  **Currently, Reset PW hangs on the client side because no error is returned. This PR ensures an error is sent back to client if Reset PW encountered an error.**

2. **Also, this PR adds functionality to be more specific about user account creation messages:** 

- username already taken: "_There is already any account configured for this username. Please use a different one, or you can use the Reset Password option to access the account."_
- email already taken: _"There is already any account configured for this email. Please use a different one, or you can use the Reset Password option to access the account."_
- email not valid: _"Please enter a valid email with the correct format, such as test@mail.com"_

![image](https://user-images.githubusercontent.com/8744689/108282476-89436480-7136-11eb-96b1-bae592d00484.png)

![image](https://user-images.githubusercontent.com/8744689/108282482-8e081880-7136-11eb-990d-ce53726caf36.png)

![image](https://user-images.githubusercontent.com/8744689/108282497-93656300-7136-11eb-9cb4-9a1d126c23a0.png)
