### PR TITLE
Helen/keep pw same until reset by user

### DIFF
--- a/models/Users.js
+++ b/models/Users.js
@@ -71,7 +71,8 @@ const user = (sequelize, DataTypes) => {
         user.password = bcrypt.hashSync(user.password, salt);
       },
       beforeUpdate: (user) => {
-        if (user.password !== undefined && user.password.length > 0) {
+        if ("password" in user._changed && user._changed.password && user.password !== undefined && user.password.length > 0) {
+          console.log("hi")
           const salt = bcrypt.genSaltSync();
           user.password = bcrypt.hashSync(user.password, salt);
         }


### PR DESCRIPTION
Before updating a password, make sure that the password field was the one that was explicitly changed. 

If the user is requested a reset PW link or is changing their username/name/email, these should not trigger a password update. The same password should still be valid after.

closes #97 