### PR TITLE
Make grade thresholds >= and not >

### DIFF
--- a/routes/grades.js
+++ b/routes/grades.js
@@ -256,10 +256,10 @@ router.get('/grades', (req, res) => {
           total_comments: annotations[student.id].length,
         };
         let possibleGrades = gradingSystem.GradingThresholds.filter(threshold =>
-            gradeLine.total_words > threshold.total_words &&
-            gradeLine.total_chars > threshold.total_chars &&
-            gradeLine.total_tags > threshold.total_tags &&
-            gradeLine.total_comments > threshold.total_comments &&
+            gradeLine.total_words >= threshold.total_words &&
+            gradeLine.total_chars >= threshold.total_chars &&
+            gradeLine.total_tags >= threshold.total_tags &&
+            gradeLine.total_comments >= threshold.total_comments &&
             //Go through all the criteria counts and see if satisfying annotations are enough
             (threshold.CriteriaCounts.reduce((bool, criteriaCount) =>
               (bool &&


### PR DESCRIPTION
Previously, Marc (UC Davis) found that some grade reports generated grades but they did not seem accurate.

This PR fixes grade generations so that grade thresholds give a student a certain grade as long as the number of words/chars/tags/comments are >= than the threshold.

