### PR TITLE
Make sure datetime picker format is correct for default

### DIFF
--- a/src/components/grader/Grader.vue
+++ b/src/components/grader/Grader.vue
@@ -60,7 +60,7 @@
         sources: [],
         selectedGrading: null,
         selectedSource: null,
-        date: Date.now() // TODO: default to the assignment due date instead
+        date: new Date() // TODO: default to the assignment due date instead
       }
     },
     computed: {


### PR DESCRIPTION
The default date picked in the grader datepicker is not correctly formatted for the `/grades` API call. This PR formats it with the `new Date()` to make the formats compatible. 