### PR TITLE
Use ES5 version of PDF.js for safari compatibility + add loading screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 /dist
+/public/client
 /public/js
 /public/style
 /public/uploads

--- a/public/nb_viewer.html
+++ b/public/nb_viewer.html
@@ -44,9 +44,12 @@
       background: #000
     }
   </style>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.6.347/pdf.min.js"></script>
+  <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.6.347/pdf.min.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.6.347/pdf_viewer.css">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.6.347/pdf_viewer.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.6.347/pdf_viewer.js"></script> -->
+  <script src="https://unpkg.com/pdfjs-dist@2.6.347/es5/build/pdf.min.js"></script>
+  <link rel="stylesheet" href="https://unpkg.com/pdfjs-dist@2.6.347/es5/web/pdf_viewer.css">
+  <script src="https://unpkg.com/pdfjs-dist@2.6.347/es5/web/pdf_viewer.js"></script>
 
 </head>
 
@@ -93,7 +96,8 @@ if (!pdfjsLib.getDocument || !pdfjsViewer.PDFViewer) {
 }
 
 // The workerSrc property shall be specified.
-pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.6.347/pdf.worker.js'
+// pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.6.347/pdf.worker.js'
+pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://unpkg.com/pdfjs-dist@2.6.347/es5/build/pdf.worker.js'
 
 // Some PDFs need external cmaps.
 // var CMAP_URL = "./pdfjs/web/cmaps/";

--- a/src/components/course/CourseContents.vue
+++ b/src/components/course/CourseContents.vue
@@ -145,8 +145,15 @@
   import VModal from 'vue-js-modal'
   import moment from 'moment'
   import Notifications from 'vue-notification'
+  import loading from 'vuejs-loading-screen'
   Vue.use(VModal)
   Vue.use(Notifications)
+  Vue.use(loading, {
+    bg: '#4a2270ad',
+    icon: 'refresh',
+    size: 3,
+    icon_color: 'white',
+})
 
   import 'vue-good-table/dist/vue-good-table.css'
   import { VueGoodTable } from 'vue-good-table'
@@ -388,6 +395,7 @@
         this.pdfFileUpload = this.$refs.file.files[0];
       },
       submitFile() {
+        this.$isLoading(true) // open loading screen      
         let formData = new FormData();
         formData.append('file', this.pdfFileUpload);
         formData.append('name', this.newPdfFile.name)
@@ -400,6 +408,7 @@
         }
         axios.post(`/api/files/filePdf/${this.currentDir.id}`, formData, headers)
           .then((result) =>{
+            this.$isLoading(false) // close loading screen      
             this.newPdfFile = { name: ""}
             if(!result.data.error) {
               this.loadFiles();


### PR DESCRIPTION
- Previously, we didn't use the ES5 version of PDF.js. This change uses the unpkg CDN that hosts an ES5 version of PDF.js so that NBv2 PDF viewer works on safari
- Add a loading screen when uploading a PDF in case it takes a while to give user some more feedback (https://github.com/haystack/nb/issues/126)

![image](https://user-images.githubusercontent.com/8744689/112918924-deba4c00-90ba-11eb-98e5-15e49b804d8e.png)
