### PR TITLE
Helen/add spotlight log notification

### DIFF
--- a/migrations/20210420060756-edit-spotlightlogs-enum.js
+++ b/migrations/20210420060756-edit-spotlightlogs-enum.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.query("ALTER TYPE enum_spotlight_logs_type ADD VALUE 'NOTIFICATION_HIGHLIGHT'")
+        await queryInterface.sequelize.query("ALTER TYPE enum_spotlight_logs_type ADD VALUE 'NOTIFICATION_LIST'")
+        await queryInterface.sequelize.query("ALTER TYPE enum_spotlight_logs_type ADD VALUE 'NOTIFICATION_POPUP'")
+    }
+
+};

--- a/migrations/20210427212704-add-trigger-column.js
+++ b/migrations/20210427212704-add-trigger-column.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.addColumn('spotlight_logs', 'trigger', {
+            type: Sequelize.ENUM,
+            values: ['NONE', 'INSTRUCTOR_COMMENTED', 'REPLY_REQUESTED', 'USER_TAGGED', 'USER_SAW_RECENT_ACTIVITY']
+        });
+        
+    },
+    
+    down: async (queryInterface, Sequelize) => {
+        await queryInterface.removeColumn('spotlight_logs', 'trigger');
+        await queryInterface.sequelize.query('DROP TYPE IF EXISTS "enum_spotlight_logs_trigger";');
+    }
+};

--- a/models/Spotlights/SpotlightsLog.js
+++ b/models/Spotlights/SpotlightsLog.js
@@ -17,6 +17,10 @@ const spotlightLog = (sequelize, DataTypes) => {
             type: DataTypes.ENUM,
             values: ['INSTRUCTOR', 'STUDENT']
         },
+        trigger: {
+            type: DataTypes.ENUM,
+            values: ['NONE', 'INSTRUCTOR_COMMENTED', 'REPLY_REQUESTED', 'USER_TAGGED', 'USER_SAW_RECENT_ACTIVITY']
+        }
     },
     {
         classMethods:{

--- a/models/Spotlights/SpotlightsLog.js
+++ b/models/Spotlights/SpotlightsLog.js
@@ -11,7 +11,7 @@ const spotlightLog = (sequelize, DataTypes) => {
         },
         type: {
             type: DataTypes.ENUM,
-            values: ['NONE', 'IN', 'ABOVE', 'BELLOW', 'LEFT', 'RIGHT', 'EM', 'MARGIN', 'LIST', 'HIGHLIGHT']
+            values: ['NONE', 'IN', 'ABOVE', 'BELLOW', 'LEFT', 'RIGHT', 'EM', 'MARGIN', 'LIST', 'HIGHLIGHT', 'NOTIFICATION_LIST', 'NOTIFICATION_POPUP', 'NOTIFICATION_HIGHLIGHT']
         },
         role: {
             type: DataTypes.ENUM,

--- a/routes/spotlights.js
+++ b/routes/spotlights.js
@@ -74,6 +74,7 @@ router.delete('/spotlight/:id', async (req, res) => {
  * @param type: string enum ('IN', 'ABOVE', 'BELLOW', 'LEFT', 'RIGHT', 'EM', 'MARGIN', 'NOTIFICATION_LIST', 'NOTIFICATION_POPUP', 'NOTIFICATION_HIGHLIGHT')
  * @param action: string enum ('CLICK', 'HOVER', 'LIKE', 'STAR', 'REPLY_REQUEST', 'BOOKMARK', 'REPLY')
  * @param role: string enum ('INSTRUCTOR', 'STUDENT')
+ * @param trigger: string enum ('NONE', 'INSTRUCTOR_COMMENTED', 'REPLY_REQUESTED', 'USER_TAGGED', 'USER_SAW_RECENT_ACTIVITY')
  */
 router.post('/log', async (req, res) => {
     const spotlight = req.body.spotlight_id ? await Spotlight.findByPk(req.body.spotlight_id) : {}
@@ -92,6 +93,7 @@ router.post('/log', async (req, res) => {
                 role: req.body.role.toUpperCase(),
                 class_id: req.body.class_id,
                 source_id: source.id,
+                trigger: req.body.trigger ? req.body.trigger : 'NONE'
             }, 
         )
         res.status(200).json(spotlightLog)

--- a/routes/spotlights.js
+++ b/routes/spotlights.js
@@ -71,7 +71,7 @@ router.delete('/spotlight/:id', async (req, res) => {
  * Make new spotlight log for a given annotation
  * @name POST/api/spotlights/log
  * @param annotationId: annotation id to innotate
- * @param type: string enum ('IN', 'ABOVE', 'BELLOW', 'LEFT', 'RIGHT', 'EM', 'MARGIN')
+ * @param type: string enum ('IN', 'ABOVE', 'BELLOW', 'LEFT', 'RIGHT', 'EM', 'MARGIN', 'NOTIFICATION_LIST', 'NOTIFICATION_POPUP', 'NOTIFICATION_HIGHLIGHT')
  * @param action: string enum ('CLICK', 'HOVER', 'LIKE', 'STAR', 'REPLY_REQUEST', 'BOOKMARK', 'REPLY')
  * @param role: string enum ('INSTRUCTOR', 'STUDENT')
  */


### PR DESCRIPTION
- Add migration file to add NOTIFICATION_POPUP, NOTIFICATION_LIST, NOTIFICATION_HIGHLIGHT to spotlight logging for sync project
- (If migration wants to be reverted, refer to the `down` command of removing the enum type altogether)

- Update backend model to reflect new enum values

- Add column for `interaction_trigger_type`, which is what caused the user to click on a notification/highlight (if someone got the notification that they were tagged and clicked on it, then that'll log the "USER_TAGGED" type. If they click on a blinking recent activity thread, then that'll log "USER_SAW_RECENT_ACTIVITY". That also applies for "INSTRUCTOR_COMMENTED" and "REPLY_REQUESTED". Other types of interactions with be "NONE".

Example of new values stored in database (please ignore the `interaction_trigger_type` column)
![image](https://user-images.githubusercontent.com/8744689/116453356-a0c45b00-a813-11eb-82cd-a7f0c15a7eff.png)
