### PR TITLE
Modify new reply to add corresponding reply annotation id

### DIFF
--- a/routes/annotations.js
+++ b/routes/annotations.js
@@ -772,7 +772,8 @@ router.post('/new_reply/:id', (req, res)=>{
             authorId: req.user.id, 
             threadId: parent.Thread.id, 
             headAnnotationId: parent.Thread.HeadAnnotation.id, 
-            taggedUsers: [...req.body.userTags]
+            taggedUsers: [...req.body.userTags],
+            newAnnotationId: child.id
           })
       });
       parent.addChild(child);


### PR DESCRIPTION
For new_reply socket.io endpoint, also emit information about the reply thread, so that we can tell users more accurate messages about what was actually posted