### PR TITLE
NB Demo Video Embedded Into Log In Page

### DIFF
--- a/src/views/TopPage.vue
+++ b/src/views/TopPage.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="app-wrapper">
     <nav-bar></nav-bar>
+    <div class="video-wrapper">
+      <iframe width="100%" height="100%" src="https://www.youtube.com/embed/G0ghiJWkHYY" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    </div>
     <div class="app-body">
       <user-create></user-create>
       <div class="v-divide"></div>
@@ -81,5 +84,13 @@
     width: 0;
     height: 100%;
     border: solid 1px #aaa;
+  }
+
+  .video-wrapper {
+    position: absolute;
+    padding: 3.5%;
+    width: 40%;
+    height: 40%;
+    top: 400px;
   }
 </style>


### PR DESCRIPTION
NB Demo Video now embedded into log in page below the create an account section

Features:
- Adjusts as the size of the window is increased and decreased
- Link of youtube video is embedded and loads properly 
- Front page scrollable when video overlaps a bit 

Changes:
- frontend: added new container to hold iframe of video for front page

Normal overview 
![Normal Size overview](https://user-images.githubusercontent.com/35709638/123726280-b5e25800-d85d-11eb-91a4-81e2a171c5cb.PNG)

Smaller sized screen
![Smaller screen view plus scrollbar](https://user-images.githubusercontent.com/35709638/123726333-ca265500-d85d-11eb-9bf3-acc303b1e7c7.PNG)

Skinny screen
![Skinny Screen View](https://user-images.githubusercontent.com/35709638/123726384-df02e880-d85d-11eb-89fe-e546411be91a.PNG)


