### PR TITLE
Updated Grading to One Minute Rather than 15 Minute Intervals

### DIFF
--- a/src/components/course/CourseContents.vue
+++ b/src/components/course/CourseContents.vue
@@ -101,7 +101,7 @@
                 v-model="edittingFile.newDeadline"
                 type="datetime"
                 :inline="true"
-                minute-step="15"
+                minute-step="1"
                 use12-hour="true"
                 :bootstrap-styling="true">
             </Datetime>


### PR DESCRIPTION
Issue #57 Changed time interval from 15 minutes to 1 minute to give more flexibility in setting the due date of an assignment. Still working on updating the secondary deadline to automatically fill with the current due date for the grading tab. 