### PR TITLE
Remove `.pdf` from default URL

### DIFF
--- a/public/nb_viewer.html
+++ b/public/nb_viewer.html
@@ -77,7 +77,7 @@
 <script type="text/javascript">
     const queryString = window.location.search;
     const urlParams = new URLSearchParams(queryString);
-    const DEFAULT_URL = `uploads/${urlParams.get('id')}.pdf`
+    const DEFAULT_URL = `uploads/${urlParams.get('id')}`
     document.getElementById("download").setAttribute("href", DEFAULT_URL)
     run()
 


### PR DESCRIPTION
Previous code for loading the PDF into the pdf viewer set the URL as `"uploads/" + urlParams.get('id')` but new one adds the `".pdf"` extension, which seemingly is causing a 404 error:

![image](https://github.com/haystack/nb/assets/16576314/1ae45f77-d386-4d66-ab1b-3c549da6c86e)
 